### PR TITLE
Bugfix: Reverted path variable back to use correct template syntax. 

### DIFF
--- a/lualint
+++ b/lualint
@@ -128,11 +128,12 @@ local function locate(name)
   end
 
   -- Add current directory
-  paths = paths .. ";./"
+  paths = paths .. ";./?.lua"
 
   for path in string.gfind(paths, "[^;]+") do
     -- Construct full filename from path, module name and file extension
-    path = path .. name .. ".lua"
+    path = string.gsub(path, "?", name)
+
     if fileexists(path) then
       return path
     end

--- a/lualint
+++ b/lualint
@@ -117,14 +117,14 @@ local function locate(name)
   local paths = ""
 
   if type(LUA_PATH) == "string" then
-     -- Use the LUA_PATH variable
-     paths = LUA_PATH
-  else 
-     -- Try to get the LUA_PATH env variable
-     local env_lua_path = os.getenv "LUA_PATH"
-     if type(env_lua_path) == "string" then
-	paths = env_lua_path
-     end
+    -- Use the LUA_PATH variable
+    paths = LUA_PATH
+  else
+    -- Try to get the LUA_PATH env variable
+    local env_lua_path = os.getenv "LUA_PATH"
+    if type(env_lua_path) == "string" then
+      paths = env_lua_path
+    end
   end
 
   -- Add current directory
@@ -132,7 +132,7 @@ local function locate(name)
 
   for path in string.gfind(paths, "[^;]+") do
     -- Construct full filename from path, module name and file extension
-    path = path .. name .. ".lua"     
+    path = path .. name .. ".lua"
     if fileexists(path) then
       return path
     end

--- a/lualint
+++ b/lualint
@@ -113,16 +113,24 @@ end
 
 -- borrowed from LTN11
 local function locate(name)
-  local path = LUA_PATH
 
-  if type(path) ~= "string" then
-    path = os.getenv "LUA_PATH" .. ";"
+  local paths = ""
+
+  if type(LUA_PATH) == "string" then
+     -- Use the LUA_PATH variable
+     paths = LUA_PATH
+  else 
+     -- Try to get the LUA_PATH env variable
+     local env_lua_path = os.getenv "LUA_PATH"
+     if type(env_lua_path) == "string" then
+	paths = env_lua_path
+     end
   end
 
   -- Add current directory
-  path = path .. "./"
+  paths = paths .. ";./"
 
-  for path in string.gfind(path, "[^;]+") do
+  for path in string.gfind(paths, "[^;]+") do
     -- Construct full filename from path, module name and file extension
     path = path .. name .. ".lua"     
     if fileexists(path) then


### PR DESCRIPTION
Section "5.3 - Modules" in http://www.lua.org/manual/5.1/manual.html describes the syntax of the LUA_PATH string as follows:
"./?.lua;./?.lc;/usr/local/?/init.lua". 
This was broken by me in a previous commit.
